### PR TITLE
Network ASM: removed redundant params from 'diagnositcs get'

### DIFF
--- a/lib/commands/asm/network._js
+++ b/lib/commands/asm/network._js
@@ -767,9 +767,6 @@ exports.init = function (cli) {
     .usage('[options] <vnet-name>')
     .description($('Get current diagnostics session in a virtual network gateway'))
     .option('-n, --vnet-name <vnet-name>', $('the name of the virtual network'))
-    .option('-o, --vendor <vendor>', $('the vendor of the VPN device'))
-    .option('-p, --platform <platform>', $('the platform of the VPN device'))
-    .option('-f, --os-family <os-family>', $('the OS family of the VPN device'))
     .option('-s, --subscription <id>', $('the subscription id'))
     .execute(function (vnetName, options, _) {
       vnetName = cli.interaction.promptIfNotGiven($('Virtual network name: '), vnetName, _);


### PR DESCRIPTION
Related issue #270 